### PR TITLE
Closes #65: Update for new backend API, updated ResultsList

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -6,6 +6,15 @@ export default class SleuthClient {
     }
 
     /**
+     * Returns a Response object in JSON format.
+     * @param {Response} response The response to our request that the `fetch`
+     * API returns.
+     */
+    static _json(response) {
+        return response.json();
+    }
+
+    /**
      * Returns a string representation of the given parameters to be used in a
      * HTTP request.
      * @param {Object} params A JSON object of key value pairs representing the
@@ -27,26 +36,26 @@ export default class SleuthClient {
      * @param {Object} params
      */
     async _get(endpoint, params) {
-        const uri = this.url + endpoint + SleuthClient._stringParams(params);
-        return new Promise(function(resolve, reject) {
-            fetch(uri).then(response => response.json())
-            .then(response => resolve(response))
-            .catch(error => {
-                console.trace(error)
-                reject(error)
-            });
-        })
+        try {
+            const uri = this.url + endpoint + SleuthClient._stringParams(params);
+            const response = await fetch(uri);
+            return await SleuthClient._json(response);
+        } catch (ex) {
+            throw ex;
+        }
     }
 
     /**
      * Makes a search API call to the given core with the given query and returns
      * the response in JSON format, or throws an error.
      * @param {String} query
+     * @param {String} core
      */
-    async search(query) {
+    async search(query, core) {
         return await this._get('/search', {
             q: query,
-            return: 'siteName,links'
+            core: core,
+            return: 'siteName,children,subjectData',
         });
     }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -46,7 +46,7 @@ export default class SleuthClient {
     async search(query) {
         return await this._get('/search', {
             q: query,
-            return: 'siteName,children'
+            return: 'siteName,links'
         });
     }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -6,15 +6,6 @@ export default class SleuthClient {
     }
 
     /**
-     * Returns a Response object in JSON format.
-     * @param {Response} response The response to our request that the `fetch`
-     * API returns.
-     */
-    static _json(response) {
-        return response.json();
-    }
-
-    /**
      * Returns a string representation of the given parameters to be used in a
      * HTTP request.
      * @param {Object} params A JSON object of key value pairs representing the
@@ -36,25 +27,26 @@ export default class SleuthClient {
      * @param {Object} params
      */
     async _get(endpoint, params) {
-        try {
-            const uri = this.url + endpoint + SleuthClient._stringParams(params);
-            const response = await fetch(uri);
-            return await SleuthClient._json(response);
-        } catch (ex) {
-            throw ex;
-        }
+        const uri = this.url + endpoint + SleuthClient._stringParams(params);
+        return new Promise(function(resolve, reject) {
+            fetch(uri).then(response => response.json())
+            .then(response => resolve(response))
+            .catch(error => {
+                console.trace(error)
+                reject(error)
+            });
+        })
     }
 
     /**
      * Makes a search API call to the given core with the given query and returns
      * the response in JSON format, or throws an error.
      * @param {String} query
-     * @param {String} core
      */
-    async search(query, core) {
+    async search(query) {
         return await this._get('/search', {
             q: query,
-            core: core
+            return: 'siteName,children'
         });
     }
 }

--- a/src/components/ResultList.js
+++ b/src/components/ResultList.js
@@ -19,6 +19,7 @@ export default class ResultList extends React.Component {
                     url={result.url}
                     description={result.description}
                     pageName={result.pageName}
+                    siteName={result.siteName}
                 />
             </div>
         );

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -14,6 +14,7 @@ export default class SearchForm extends React.Component {
         this.handleChange = this.handleChange.bind(this);
         this.handleKeyPress = this.handleKeyPress.bind(this);
         this.handleResponse = this.handleResponse.bind(this);
+        this.handleError = this.handleError.bind(this);
         this.getResults = this.getResults.bind(this);
         this.getMessage = this.getMessage.bind(this);
     }
@@ -58,21 +59,35 @@ export default class SearchForm extends React.Component {
      * @param {Object} response
      */
     handleResponse(response) {
-        // TODO: handle CourseItem
-        const docs = response.data[1].response.docs;
-        const highlights = response.data[1].highlighting;
-        let results = docs.map((doc, index) => {
-            console.log(doc.description != '' ? doc.description : highlights[doc.id].content[0])
-            console.log(doc.name)
-            console.log(doc.siteName != '' ? doc.siteName : '')
-            return {
-                url: doc.id,
-                description: doc.description != '' ? doc.description : highlights[doc.id].content[0],
-                pageName: doc.name,
-                siteName: doc.siteName != '' ? doc.siteName : ''
-            }
-        });
+        let results = [];
+        for (var i = 0; i < response.data.length; i++) {
+            const dataset = response.data[i];
+            const docs = dataset.response.docs;
+            const highlights = dataset.highlighting;
+            switch (dataset.type) {
+                case "genericPage":
+                    results = results.concat(docs.map(doc => {
+                        return {
+                            url: doc.id,
+                            description: doc.description != '' ? doc.description : highlights[doc.id].content[0],
+                            pageName: doc.name,
+                            siteName: doc.siteName != '' ? doc.siteName : ''
+                        }
+                    }));
+                    break;
 
+                case "courseItem":
+                    results = results.concat(docs.map(doc => {
+                        return {
+                            url: doc.id,
+                            description: doc.description,
+                            pageName: doc.name,
+                            siteName: doc.subjectData.length == 2 ? doc.subjectData[1] : ''
+                        }
+                    }))
+                    break;
+            }
+        }
         this.setState({ results: results, noResults: results.length === 0 });
     }
 

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -48,7 +48,7 @@ export default class SearchForm extends React.Component {
     handleSubmit(event) {
         if (this.state.query.length === 0) return;
         this.setState({ noResults: false });
-        this.props.client.search(this.state.query, 'genericPage')
+        this.props.client.search(this.state.query)
             .then(this.handleResponse)
             .catch(this.handleError);
     }
@@ -58,13 +58,18 @@ export default class SearchForm extends React.Component {
      * @param {Object} response
      */
     handleResponse(response) {
-        const docs = response.response.docs;
-        const highlights = response.highlighting;
+        // TODO: handle CourseItem
+        const docs = response.data[1].response.docs;
+        const highlights = response.data[1].highlighting;
         let results = docs.map((doc, index) => {
+            console.log(doc.description != '' ? doc.description : highlights[doc.id].content[0])
+            console.log(doc.name)
+            console.log(doc.siteName != '' ? doc.siteName : '')
             return {
                 url: doc.id,
-                description: doc.description ? doc.description[0] : highlights[doc.id].content[0],
-                pageName: doc.pageName ? doc.pageName : doc.siteName
+                description: doc.description != '' ? doc.description : highlights[doc.id].content[0],
+                pageName: doc.name,
+                siteName: doc.siteName != '' ? doc.siteName : ''
             }
         });
 

--- a/src/components/SearchResult.js
+++ b/src/components/SearchResult.js
@@ -24,11 +24,12 @@ export default class SearchResult extends React.Component {
         const description = this.highlight(this.props.description);
         const url = this.props.pageName ? this.props.pageName : this.props.url;
         return (
-            <div className='container' style={styles.resultsContainer}>
-                <a href={this.props.url}>{url}</a>
-                {this.props.siteName ? <p>{this.props.siteName}</p> : null}
-                {description}
-            </div>
+            <p className='container' style={styles.resultsContainer}>
+                <a href={this.props.url} style={styles.urlTitle}>{url}</a>
+                <br />
+                {this.props.siteName ? <text style={styles.siteTitle}>{this.props.siteName}</text> : null}
+                <text style={styles.descriptionStyle}>{description}</text>
+            </p>
         )
     }
 }
@@ -37,6 +38,18 @@ const styles = {
     resultsContainer: {
         textAlign: 'left',
         margin: 'auto',
-        width: '100%'
+        width: '100%',
+    },
+    urlTitle: {
+        color: 'navy',
+        fontWeight: 'bold',
+        fontSize: '125%',
+    },
+    siteTitle: {
+        color: 'grey',
+        fontWeight: 'bold',
+    },
+    descriptionStyle: {
+        fontSize: '90%',
     }
 }

--- a/src/components/SearchResult.js
+++ b/src/components/SearchResult.js
@@ -24,12 +24,12 @@ export default class SearchResult extends React.Component {
         const description = this.highlight(this.props.description);
         const url = this.props.pageName ? this.props.pageName : this.props.url;
         return (
-            <p className='container' style={styles.resultsContainer}>
+            <div className='container' style={styles.resultsContainer}>
                 <a href={this.props.url} style={styles.urlTitle}>{url}</a>
                 <br />
-                {this.props.siteName ? <text style={styles.siteTitle}>{this.props.siteName}</text> : null}
-                <text style={styles.descriptionStyle}>{description}</text>
-            </p>
+                {this.props.siteName ? <p style={styles.siteTitle}>{this.props.siteName}</p> : null}
+                <p style={styles.descriptionStyle}>{description}</p>
+            </div>
         )
     }
 }


### PR DESCRIPTION
## Related Issue
[#65](https://github.com/ubclaunchpad/sleuth/issues/65)

## Description
* 🆕 Updated client API requests and response handling to accommodate new backend API (see [#66](https://github.com/ubclaunchpad/sleuth/pull/66)), including multicore search
* 📘 Update `ResultsList` to show `pageName` and `siteName` with new styles, as well as `courseItem`

## WIKI Updates
* n0ne

## Todos
- [x] Make pretty